### PR TITLE
feat(libs): upgrade libs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
     "name": "with-typescript",
     "version": "0.1.0",
     "dependencies": {
-        "@testing-library/jest-dom": "^5.12.0",
-        "@testing-library/react": "^11.2.7",
+        "@testing-library/jest-dom": "^5.14.1",
+        "@testing-library/react": "^12.0.0",
         "@testing-library/user-event": "^13.1.9",
         "@types/react-router-dom": "^5.1.7",
         "@ui5/webcomponents": "^1.0.0-rc.14",
         "@ui5/webcomponents-fiori": "1.0.0-rc.14",
         "@ui5/webcomponents-icons": "1.0.0-rc.14",
-        "@ui5/webcomponents-react": "^0.16.0",
+        "@ui5/webcomponents-react": "^0.16.4",
         "jest-environment-jsdom-sixteen": "^2.0.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -44,9 +44,9 @@
     },
     "devDependencies": {
         "@types/jest": "^26.0.23",
-        "@types/node": "^15.6.1",
-        "@types/react": "^17.0.8",
-        "@types/react-dom": "^17.0.3",
-        "typescript": "^4.3.2"
+        "@types/node": "^15.12.4",
+        "@types/react": "^17.0.11",
+        "@types/react-dom": "^17.0.8",
+        "typescript": "^4.3.4"
     }
 }


### PR DESCRIPTION
Bump @testing-library/react from 11.2.7 to 12.0.0 dependencies
#23 opened 5 days ago by dependabot bot

Bump @types/node from 15.6.1 to 15.12.4 dependencies
#22 opened 7 days ago by dependabot bot

Bump @types/react-dom from 17.0.5 to 17.0.8 dependencies
#21 opened 10 days ago by dependabot bot

Bump typescript from 4.3.2 to 4.3.4 dependencies
#20 opened 10 days ago by dependabot bot

Bump @testing-library/jest-dom from 5.12.0 to 5.14.1 dependencies
#18 opened 14 days ago by dependabot bot

Bump @ui5/webcomponents-react from 0.16.1 to 0.16.4 dependencies
#17 opened 14 days ago by dependabot bot

Bump @types/react from 17.0.8 to 17.0.11 dependencies
#16 opened 18 days ago by dependabot bot
